### PR TITLE
Allow error message to be display in notice

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -327,9 +327,15 @@ export default class ImageTool {
    */
   uploadingFailed(errorText) {
     console.log('Image Tool: uploading failed because of', errorText);
-
+    
+    let errorMessage = 'Can not upload an image, try another.';
+    let errorJson = JSON.parse(errorText);
+    if (errorJson.hasOwnProperty('message')) {
+      errorMessage = errorJson.message;  
+    }
+    
     this.api.notifier.show({
-      message: 'Can not upload an image, try another',
+      message: errorMessage,
       style: 'error'
     });
     this.ui.hidePreloader();


### PR DESCRIPTION
Allow error message to be returned from server side (and displayed in notice) together with success: 0 in the following form:

```
{
     "success": "0",
     "message": "File too large"
}
```

cc @neSpecc 