### PR TITLE
Feature: Cropping images

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Image Block for the [Editor.js](https://editorjs.io).
 - Pasting files and screenshots from Clipboard
 - Allows adding a border, and a background
 - Allows stretching an image to the container's full-width
+- Allows image to be cropped before sending to webserver. Only works for upload by file
 
 **Notes**
 
@@ -98,6 +99,8 @@ Image Tool supports these configuration parameters:
 | buttonContent | `string` | Allows to override HTML content of «Select file» button |
 | uploader | `{{uploadByFile: function, uploadByUrl: function}}` | Optional custom uploading methods. See details below. |
 | actions | `array` | Array with custom actions to show in the tool's settings menu. See details below. |
+| withCropper | `boolean` | When is marked as true, the ImageTool will show an cropping area |
+| cropperConfigs | `Object` | [croppjs options](https://github.com/fengyuanchen/cropperjs)  |
 
 Note that if you don't implement your custom uploader methods, the `endpoints` param is required.
 
@@ -283,5 +286,34 @@ var editor = EditorJS({
   }
 
   ...
+});
+```
+
+## ImageTool with cropping
+
+```javascript
+var editor = new EditorJS({
+        /**
+         * Id of Element that should contain the Editor
+         */
+        holder: 'editor',
+        placeholder: 'Let`s write an awesome story!',
+        tools: {
+            image: {
+                class: ImageTool,
+                config: {
+                    captionPlaceholder: 'Caption',
+                    endpoints: {
+                        byFile: 'http://localhost:8008/upload/file',
+                        byUrl: 'http://localhost:8008/upload/url'
+                    },
+                    withCropper: true,
+                    cropperConfigs: {
+                        aspectRatio: 2/3
+                    }
+                },
+            }
+        }
+    });
 });
 ```

--- a/dev/index.html
+++ b/dev/index.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Test image tool</title>
+    <meta http-equiv="x-ua-compatible" content="ie=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+
+    <script src="https://cdn.jsdelivr.net/npm/@editorjs/editorjs@latest"></script>
+    <script src="./../dist/bundle.js"></script>
+
+    <script>
+        var editor;
+
+        window.addEventListener('DOMContentLoaded', function () {
+
+            editor = new EditorJS({
+                /**
+                 * Id of Element that should contain the Editor
+                 */
+                holder: 'editor',
+                placeholder: 'Let`s write an awesome story!',
+                tools: {
+                    image: {
+                        class: ImageTool,
+                        config: {
+                            captionPlaceholder: 'Caption',
+                            endpoints: {
+                                byFile: 'http://localhost:8008/upload/file',
+                                byUrl: 'http://localhost:8008/upload/url'
+                            },
+                            withCropper: true,
+                            cropperConfigs: {
+                                aspectRatio: 2/3
+                            }
+                        },
+                    }
+                }
+            });
+        });
+
+    </script>
+
+</head>
+<body>
+
+<div id="editor"></div>
+
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@editorjs/image",
-  "version": "2.6.0",
+  "version": "2.6.1",
   "keywords": [
     "codex editor",
     "tool",
@@ -42,6 +42,7 @@
     "style-loader": "^1.1.4",
     "svg-inline-loader": "^0.8.0",
     "webpack": "^4.29.5",
-    "webpack-cli": "^3.2.3"
+    "webpack-cli": "^3.2.3",
+    "cropperjs": "^1.5.11"
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@codexteam/ajax": "^4.2.0",
     "babel-loader": "^8.0.5",
     "css-loader": "^3.5.2",
-    "eslint": "^6.8.0",
+    "eslint": "^7.8.0",
     "eslint-config-codex": "^1.3.3",
     "eslint-loader": "^4.0.0",
     "formidable": "^1.2.1",

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,5 @@
+@import "https://cdnjs.cloudflare.com/ajax/libs/cropperjs/1.5.11/cropper.css";
+
 .image-tool {
   --bg-color: #cdd1e0;
   --front-color: #388ae5;
@@ -43,6 +45,16 @@
     }
   }
 
+  &__cropper-container {
+      height: 300px;
+      overflow: scroll;
+   }
+
+  &__cropper-canvas-btn {
+      width: 100%;
+      height: 30px;
+  }
+
   &__caption {
     &[contentEditable="true"][data-placeholder]::before {
       position: absolute !important;
@@ -74,6 +86,10 @@
     ^&__caption {
       display: none;
     }
+
+    ^&__cropper {
+      display: none;
+    }
   }
 
   &--filled {
@@ -85,6 +101,24 @@
       &-preloader {
         display: none;
       }
+    }
+
+    ^&__cropper {
+      display: none;
+    }
+  }
+
+  &--cropping {
+    ^&__caption {
+      display: none
+    }
+
+    ^&__image-preloader {
+      display: none
+    }
+
+    .cdx-button {
+      display: none;
     }
   }
 
@@ -101,6 +135,10 @@
     }
 
     .cdx-button {
+      display: none;
+    }
+
+    ^&__cropper {
       display: none;
     }
   }

--- a/src/index.js
+++ b/src/index.js
@@ -64,7 +64,7 @@ import Uploader from './uploader';
  * @property {function(File): Promise.<UploadResponseFormat>} [uploader.uploadByFile] - method that upload image by File
  * @property {function(string): Promise.<UploadResponseFormat>} [uploader.uploadByUrl] - method that upload image by URL
  * @property {string} withCropper - if user wants to crop selected photo
- * @property {Object} cropperConfigs - @see {@link https://github.com/fengyuanchen/cropperjs}
+ * @property {object} cropperConfigs - @see {@link https://github.com/fengyuanchen/cropperjs}
  */
 
 /**
@@ -125,7 +125,7 @@ export default class ImageTool {
       uploader: config.uploader || undefined,
       actions: config.actions || [],
       withCropper: config.withCropper || false,
-      cropperConfigs: config.cropperConfigs || {}
+      cropperConfigs: config.cropperConfigs || {},
     };
 
     /**
@@ -329,6 +329,7 @@ export default class ImageTool {
    *
    * @param {object} file - uploaded file data
    */
+  // eslint-disable-next-line accessor-pairs
   set image(file) {
     this._data.file = file || {};
 
@@ -404,9 +405,9 @@ export default class ImageTool {
 
         this.api.blocks.stretchBlock(blockId, value);
       })
-          .catch(err => {
-            console.error(err);
-          });
+        .catch(err => {
+          console.error(err);
+        });
     }
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -63,6 +63,8 @@ import Uploader from './uploader';
  * @property {object} [uploader] - optional custom uploader
  * @property {function(File): Promise.<UploadResponseFormat>} [uploader.uploadByFile] - method that upload image by File
  * @property {function(string): Promise.<UploadResponseFormat>} [uploader.uploadByUrl] - method that upload image by URL
+ * @property {string} withCropper - if user wants to crop selected photo
+ * @property {Object} cropperConfigs - @see {@link https://github.com/fengyuanchen/cropperjs}
  */
 
 /**
@@ -122,6 +124,8 @@ export default class ImageTool {
       buttonContent: config.buttonContent || '',
       uploader: config.uploader || undefined,
       actions: config.actions || [],
+      withCropper: config.withCropper || false,
+      cropperConfigs: config.cropperConfigs || {}
     };
 
     /**
@@ -139,12 +143,12 @@ export default class ImageTool {
     this.ui = new Ui({
       api,
       config: this.config,
-      onSelectFile: () => {
+      onSelectFile: (file) => {
         this.uploader.uploadSelectedFile({
           onPreview: (src) => {
             this.ui.showPreloader(src);
           },
-        });
+        }, file);
       },
       readOnly,
     });
@@ -400,9 +404,9 @@ export default class ImageTool {
 
         this.api.blocks.stretchBlock(blockId, value);
       })
-        .catch(err => {
-          console.error(err);
-        });
+          .catch(err => {
+            console.error(err);
+          });
     }
   }
 

--- a/src/ui.js
+++ b/src/ui.js
@@ -31,10 +31,10 @@ export default class Ui {
       caption: make('div', [this.CSS.input, this.CSS.caption], {
         contentEditable: !this.readOnly,
       }),
-      cropper: make('div', [this.CSS.cropper]),
-      cropperContainer: make('div', [this.CSS.cropperContainer]),
-      cropperCanvas : make('canvas', [this.CSS.cropperCanvas]),
-      cropperCanvasButton: this.createCroppedButton()
+      cropper: make('div', [ this.CSS.cropper ]),
+      cropperContainer: make('div', [ this.CSS.cropperContainer ]),
+      cropperCanvas: make('canvas', [ this.CSS.cropperCanvas ]),
+      cropperCanvasButton: this.createCroppedButton(),
     };
 
     /**
@@ -57,11 +57,10 @@ export default class Ui {
     this.nodes.wrapper.appendChild(this.nodes.caption);
     this.nodes.wrapper.appendChild(this.nodes.fileButton);
 
-    this.nodes.cropperContainer.appendChild(this.nodes.cropperCanvas)
+    this.nodes.cropperContainer.appendChild(this.nodes.cropperCanvas);
     this.nodes.cropper.appendChild(this.nodes.cropperContainer);
     this.nodes.cropper.appendChild(this.nodes.cropperCanvasButton);
     this.nodes.wrapper.appendChild(this.nodes.cropper);
-
   }
 
   /**
@@ -137,10 +136,10 @@ export default class Ui {
 
     button.addEventListener('click', () => {
       if (this.config.withCropper) {
-        ajax.selectFiles({accept: this.config.types})
-            .then((files) => {
-              this.showCropper(files[0]);
-            });
+        ajax.selectFiles({ accept: this.config.types })
+          .then((files) => {
+            this.showCropper(files[0]);
+          });
       } else {
         this.onSelectFile();
       }
@@ -152,18 +151,19 @@ export default class Ui {
   /**
    * Create send cropped file button
    *
-   * @return {Element}
+   * @returns {Element}
    */
   createCroppedButton() {
-    const button = make('button', [this.CSS.cropperConfirmButton])
+    const button = make('button', [ this.CSS.cropperConfirmButton ]);
 
     button.innerHTML = this.config.buttonCropped || `${buttonIcon} ${this.api.i18n.t('Upload photo')}`;
 
     button.addEventListener('click', () => {
       const canvas = this.getCroppedCanvas();
+
       if (canvas) {
         canvas.toBlob((blob) => {
-          this.onSelectFile(new File([blob], "fileName.jpg", { type: "image/jpeg" }));
+          this.onSelectFile(new File([ blob ], 'fileName.jpg', { type: 'image/jpeg' }));
         });
       }
     });
@@ -171,10 +171,10 @@ export default class Ui {
     return button;
   }
 
-
   /**
+   * Returns cropped canvas
    *
-   * @return {null|HTMLCanvasElement}
+   * @returns {null|HTMLCanvasElement}
    */
   getCroppedCanvas() {
     return this.cropper ? this.cropper.getCroppedCanvas() : null;
@@ -184,7 +184,7 @@ export default class Ui {
    * Render cropper
    *
    * @param {File} file
-   * @return {Element}
+   * @returns {Element}
    */
   showCropper(file) {
     const canvas = this.nodes.cropperCanvas;
@@ -198,12 +198,12 @@ export default class Ui {
       ctx.canvas.height = img.height;
       // draw image
       ctx.drawImage(img, 0, 0, ctx.canvas.width, ctx.canvas.height);
-      this.cropper = new Cropper(canvas,this.config.cropperConfigs);
+      this.cropper = new Cropper(canvas, this.config.cropperConfigs);
     };
 
     reader.onloadend = function () {
       img.src = reader.result;
-    }
+    };
     // this is to read the file
     reader.readAsDataURL(file);
 

--- a/src/uploader.js
+++ b/src/uploader.js
@@ -24,9 +24,9 @@ export default class Uploader {
    * Fires ajax.transport()
    *
    * @param {Function} onPreview - callback fired when preview is ready
-   * @param {?File} file - if the user is using cropping
+   * @param {object} [croppedFile] - if the user is using cropping
    */
-  uploadSelectedFile({ onPreview }, file) {
+  uploadSelectedFile({ onPreview }, croppedFile) {
     const preparePreview = function (file) {
       const reader = new FileReader();
 
@@ -44,7 +44,6 @@ export default class Uploader {
 
     // custom uploading
     if (this.config.uploader && typeof this.config.uploader.uploadByFile === 'function') {
-
       const customHandler = (files) => {
         preparePreview(files[0]);
 
@@ -55,34 +54,32 @@ export default class Uploader {
         }
 
         return customUpload;
-      }
+      };
 
-      if (file) {
-        return customHandler([file]);
+      if (croppedFile) {
+        return customHandler([ croppedFile ]);
       } else {
-        upload = ajax.selectFiles({accept: this.config.types}).then((files) => {
+        upload = ajax.selectFiles({ accept: this.config.types }).then((files) => {
           return customHandler(files);
         });
       }
 
       // default uploading
     } else {
-      if (file) {
-
+      if (croppedFile) {
         const form = new FormData();
-        form.append(this.config.field, file, 'image.jpg');
+
+        form.append(this.config.field, croppedFile, 'image.jpg');
 
         upload = ajax.post({
           url: this.config.endpoints.byFile,
           data: form,
           headers: this.config.additionalRequestHeaders,
           beforeSend: () => {
-            preparePreview(file);
-          }
+            preparePreview(croppedFile);
+          },
         }).then((response) => response.body);
-
       } else {
-
         upload = ajax.transport({
           url: this.config.endpoints.byFile,
           data: this.config.additionalRequestData,
@@ -93,7 +90,6 @@ export default class Uploader {
           },
           fieldName: this.config.field,
         }).then((response) => response.body);
-
       }
     }
 


### PR DESCRIPTION
Hi all,

I have integrated croppejs in ImageTool. This integration makes image cropping possible when the user uses the upload by file method. The cropping can be turned on/off on ImageTool config.

I have the use case of cropping images before sending them to the web-server. The downside of this approach for the general public is that: or the cropping is always turn on or off (fits my use case).

It could be modified to use the tunes, and have an extra image icon to upload and crop, or another more appropriate way. 

Either way, this implementation is a suggestion, and if is accepted I can change for any way you want.

Thanks for making this tool 💯

Thanks all