### PR TITLE
Fix/README: key `endpoints` is plural (reverted from merge)

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Scenario:
 
 1. User pastes an URL of the image file to the Editor
 2. Editor pass pasted string to the Image Tool
-3. Tool sends it to **your** backend (on `config.endpoint.byUrl` route) via 'url' in request body
+3. Tool sends it to **your** backend (on `config.endpoints.byUrl` route) via 'url' in request body
 4. Your backend should accept URL, **download and save the original file by passed URL** and return file data with JSON at specified format.
 5. Image tool shows saved image and stores server answer
   


### PR DESCRIPTION
This change was reverted from PR https://github.com/editor-js/image/pull/194 in commit https://github.com/editor-js/image/pull/194/commits/d2686ee4935fcf8b2b43359d4bb311b6909c560b merging master.