### PR TITLE
Avoid double insertion of images

### DIFF
--- a/src/ui.js
+++ b/src/ui.js
@@ -194,7 +194,13 @@ export default class Ui {
      *
      * @type {Element}
      */
-    this.nodes.imageEl = make(tag, this.CSS.imageEl, attributes);
+    if (this.nodes.imageEl) {
+      for (const attrName in attributes) {
+        this.nodes.imageEl[attrName] = attributes[attrName];
+      }
+    } else {
+      this.nodes.imageEl = make(tag, this.CSS.imageEl, attributes);
+    }
 
     /**
      * Add load event listener


### PR DESCRIPTION
When uploading a new image, the existing image was not replaced, but a new image was inserted. The patch now replaces the existing image.