### PR TITLE
fix(render): resolve problem with the stretched tune

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Image Block for the [Editor.js](https://editorjs.io).
 
 This Tool requires server-side implementation for the file uploading. See [backend response format](#server-format) for more details.
 
-This Tool is also capable of uploading & displaying video files using the <video> element. To enable this, specify video mime-types via the 'types' config param.
+This Tool is also capable of uploading & displaying video files using the `<video>` element. To enable this, specify video mime-types via the 'types' config param.
 
 
 ## Installation
@@ -156,8 +156,8 @@ This Tool returns `data` with following format
 }
 ```
 
-## Backend response format <a name="server-format"></a>  
-  
+## Backend response format <a name="server-format"></a>
+
 This Tool works by one of the following schemes:
 
 1. Uploading files from the device
@@ -176,7 +176,7 @@ Scenario:
 
 So, you can implement backend for file saving by your own way. It is a specific and trivial task depending on your
 environment and stack.
-  
+
 The tool executes the request as [`multipart/form-data`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/POST), with the key as the value of `field`  in configuration.
 
 The response of your uploader **should**  cover the following format:
@@ -206,16 +206,16 @@ Scenario:
 3. Tool sends it to **your** backend (on `config.endpoints.byUrl` route) via 'url' in request body
 4. Your backend should accept URL, **download and save the original file by passed URL** and return file data with JSON at specified format.
 5. Image tool shows saved image and stores server answer
-  
+
 The tool executes the request as `application/json` with the following request body:
-  
+
 ```json5
 {
   "url": "<pasted URL from the user>"
   "additionalRequestData": "<additional request data from configuration>"
 }
 ```
-  
+
 Response of your uploader should be at the same format as described at «[Uploading files from device](#from-device)» section
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@editorjs/image",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "keywords": [
     "codex editor",
     "tool",

--- a/src/index.js
+++ b/src/index.js
@@ -450,13 +450,7 @@ export default class ImageTool {
        * Wait until the API is ready
        */
       Promise.resolve().then(() => {
-        if (this.block && this.block.id) {
-          this.block.stretched = value;
-        } else {
-          const blockId = this.api.blocks.getCurrentBlockIndex();
-
-          this.api.blocks.stretchBlock(blockId, value);
-        }
+        this.block.stretched = value;
       })
         .catch(err => {
           console.error(err);

--- a/src/index.js
+++ b/src/index.js
@@ -132,10 +132,12 @@ export default class ImageTool {
    * @param {ImageConfig} tool.config - user config for Tool
    * @param {object} tool.api - Editor.js API
    * @param {boolean} tool.readOnly - read-only mode flag
+   * @param {BlockAPI|{}} tool.block - current Block API
    */
-  constructor({ data, config, api, readOnly }) {
+  constructor({ data, config, api, readOnly, block }) {
     this.api = api;
     this.readOnly = readOnly;
+    this.block = block;
 
     /**
      * Tool's initial config
@@ -448,9 +450,13 @@ export default class ImageTool {
        * Wait until the API is ready
        */
       Promise.resolve().then(() => {
-        const blockId = this.api.blocks.getCurrentBlockIndex();
+        if (this.block && this.block.id) {
+          this.block.stretched = value;
+        } else {
+          const blockId = this.api.blocks.getCurrentBlockIndex();
 
-        this.api.blocks.stretchBlock(blockId, value);
+          this.api.blocks.stretchBlock(blockId, value);
+        }
       })
         .catch(err => {
           console.error(err);


### PR DESCRIPTION
This PR fixes 2 problems:

- When rendering image with `stretched=true` tune, the next block is stretched instead of the image (Resolves #55)
- Problem in README (Resolves #181)

