### PR TITLE
tune.js removed in comment

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,6 @@
  *  1) index.js — main Tool's interface, public API and methods for working with data
  *  2) uploader.js — module that has methods for sending files via AJAX: from device, by URL or File pasting
  *  3) ui.js — module for UI manipulations: render, showing preloader, etc
- *  4) tunes.js — working with Block Tunes: render buttons, handle clicks
  *
  * For debug purposes there is a testing server
  * that can save uploaded files and return a Response {@link UploadResponseFormat}


### PR DESCRIPTION
At commit [#9de137374609](https://github.com/editor-js/image/commit/5ee4e1ef338493b82a11fd76a3568844afe1c78b) tune.js was removed, but at comment it is still mentioned.