### PR TITLE
Changes regex to match a youtube thumbnail urls

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -283,7 +283,7 @@ export default class ImageTool {
        * Paste URL of image into the Editor
        */
       patterns: {
-        image: /https?:\/\/\S+\.(gif|jpe?g|tiff|png|svg|webp)(\?[a-z0-9=]*)?$/i,
+        image: /https?:\/\/\S+\.(gif|jpe?g|tiff|png|svg|webp)(\?[a-z0-9=\-&]*)?$/i,
       },
 
       /**


### PR DESCRIPTION
The current regex doesn't match YouTube thumbnail URLs.

Some URLs:
1. https://i.ytimg.com/vi/VVX7JIWx-ss/hqdefault.jpg?sqp=-oaymwEbCKgBEF5IVfKriqkDDggBFQAAiEIYAXABwAEG&rs=AOn4CLDDMNOn5gBjAxIMP1Yv0hOjqp2SeA
2. https://i.ytimg.com/vi/SB5BfYYpXjE/hqdefault.jpg?sqp=-oaymwEbCKgBEF5IVfKriqkDDggBFQAAiEIYAXABwAEG&rs=AOn4CLBW1gw5k9BoUDGbs7nGS81ZmzYxUw

There are two extra characters in it `-` `&`. So I've added it.