### PR TITLE
Migrate typescript

### DIFF
--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -5,6 +5,16 @@ export interface UploadOptions  {
   onPreview: (src: string) => void 
 };
 
+/**
+ * Represents the format of a file object data with the additional data.
+ */
+export type FileObjectData<AdditionalData = {}> = {
+  /**
+   * The URL of the file.
+   */
+  url: string;
+} & AdditionalData;
+
 /** 
  * User configuration of Image block tunes. Allows to add custom tunes through the config
 */

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -86,7 +86,7 @@ interface ConstructorParams {
  *  - show/hide preview
  *  - apply tune view
  */
-export default class Ui {
+export default class Ui<CustomActions = {}, AdditionalUploadResponse = {}> {
 /**
  * API instance for Editor.js.
  */
@@ -180,7 +180,7 @@ public nodes: Nodes;
    * @param {ImageToolData} toolData - saved tool data
    * @returns {Element}
    */
-  render(toolData: ImageToolData): HTMLElement  {
+  render(toolData: ImageToolData<CustomActions, AdditionalUploadResponse>): HTMLElement  {
     if (!toolData.file || Object.keys(toolData.file).length === 0) {
       this.toggleStatus(UiState.Empty);
     } else {

--- a/src/uploader.ts
+++ b/src/uploader.ts
@@ -6,7 +6,7 @@ import { UploadResponseFormat, ImageConfig } from './types/types';
 /**
  * Params interface for Uploader constructor
  */
-interface UploaderParams {
+interface UploaderParams<AdditionalUploadResponse = {}> {
   /**
    * Configuration for the uploader
    */
@@ -16,7 +16,7 @@ interface UploaderParams {
    * @param response: Callback function for successful upload
    * @returns void
    */
-  onUpload: (response: UploadResponseFormat) => void;
+  onUpload: (response: UploadResponseFormat<AdditionalUploadResponse>) => void;
   /**
    * 
    * @param error : error type
@@ -31,9 +31,9 @@ interface UploaderParams {
  *  2. Upload by pasting URL
  *  3. Upload by pasting file from Clipboard or by Drag'n'Drop
  */
-export default class Uploader {
+export default class Uploader<AdditionalUploadResponse = {}> {
   private config: ImageConfig;
-  private onUpload: (response: UploadResponseFormat) => void;
+  private onUpload: (response: UploadResponseFormat<AdditionalUploadResponse>) => void;
   private onError: (error: any) => void;
   /**
    * @param {object} params - uploader module params
@@ -41,7 +41,7 @@ export default class Uploader {
    * @param {Function} params.onUpload - one callback for all uploading (file, url, d-n-d, pasting)
    * @param {Function} params.onError - callback for uploading errors
    */
-  constructor({ config, onUpload, onError }: UploaderParams) {
+  constructor({ config, onUpload, onError }: UploaderParams<AdditionalUploadResponse>) {
     this.config = config;
     this.onUpload = onUpload;
     this.onError = onError;
@@ -67,7 +67,7 @@ export default class Uploader {
      * Custom uploading
      * or default uploading
      */
-    let upload: Promise<UploadResponseFormat>;
+    let upload: Promise<UploadResponseFormat<AdditionalUploadResponse>>;
 
     // custom uploading
     if (this.config.uploader && typeof this.config.uploader.uploadByFile === 'function') {
@@ -81,7 +81,7 @@ export default class Uploader {
           console.warn('Custom uploader method uploadByFile should return a Promise');
         }
 
-        return customUpload as Promise<UploadResponseFormat>;
+        return customUpload as Promise<UploadResponseFormat<AdditionalUploadResponse>>;
       });
 
     // default uploading
@@ -99,7 +99,7 @@ export default class Uploader {
     }
 
     upload.then((response) => {
-      this.onUpload(response);
+      this.onUpload(response as UploadResponseFormat<AdditionalUploadResponse>);
     }).catch((error) => {
       this.onError(error);
     });
@@ -137,7 +137,7 @@ export default class Uploader {
       }).then((response: any) => response.body);
     }
 
-    upload.then((response: UploadResponseFormat) => {
+    upload.then((response: UploadResponseFormat<AdditionalUploadResponse>) => {
       this.onUpload(response);
     }).catch((error: any) => {
       this.onError(error);
@@ -198,7 +198,7 @@ export default class Uploader {
     }
 
     upload.then((response) => {
-      this.onUpload(response);
+      this.onUpload(response as UploadResponseFormat<AdditionalUploadResponse>);
     }).catch((error) => {
       this.onError(error);
     });


### PR DESCRIPTION
## Problem
The current design of the `Image` class doesn't make it easily extendable so that users can define their actions and additional fields in the upload response. This also limits class extensions for use cases where custom data and actions must be implemented.

## Cause
The `Image` class was first designed with types fixed for the actions and upload response data, which is a very concrete design, and it limited the flexibility with different kinds of requirements. The approach taken in designing thus becomes relatively narrow and does not allow an extension of the user's custom properties during the creation of `Image` object.

## Solution
Generic types should be used to re-implement the `Image` class to fix this problem. The definition of the class should change into class `ImageTool<CustomActions = {}, AdditionalUploadResponse = {}>`, such that while the object of it is created, users can provide their custom actions and additional upload response types. This makes the `Image` class flexible and more usable and leaves the ability to respond to almost any scenario and requirements.

