### PR TITLE
Image replace feature

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -12,6 +12,7 @@
       max-width: 100%;
       vertical-align: bottom;
       display: block;
+      cursor: pointer;
     }
 
     &-preloader {

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -251,7 +251,14 @@ export default class Ui {
       }
     });
 
-    this.nodes.imageContainer.appendChild(this.nodes.imageEl);
+    const imageEl = this.nodes.imageEl;
+    this.nodes.imageContainer.appendChild(imageEl);
+
+    this.nodes.imageEl.addEventListener('click', () => {
+        this.toggleStatus(UiState.Empty);
+        this.nodes.imageContainer.removeChild(imageEl);
+        this.onSelectFile();
+    });
   }
 
   /**


### PR DESCRIPTION
Add a "click" event to each "imageEl" that when triggered:

1. Update the state of the container to "empty"
2. Remove the current image picture (to avoid duplications)
3. Calls the file selection method "onSelectFile()"

This way, the "fillImage" method will be called again after "onSelectFile" is fired.

Of course I would like to make it customizable to also work in "read only" scenarios and so on. But I'm not sure how to do it, sorry.

That's my first open source pull request though, i really hope it helps.
Thanks for the amazing package <3.