### PR TITLE
Support for selecting and enabling specific tunes in ImageTool

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ actions: [
 
 **_NOTE:_**  return value of `action` callback for settings whether action button should be toggled or not is *deprecated*. Consider using `toggle` option instead.
 
-Enable features such as border, background tunes and caption by adding `features`-array in the configuration:
+You can enable/disable features such as border, background tunes and caption by adding `features` array in the configuration:
 ```js
 features: {
   background: boolean,
@@ -125,6 +125,8 @@ features: {
   stretched: boolean
 }
 ```
+
+**_NOTE:_** set caption to `optional` in order to configure caption as a tune.
 
 ## Output data
 

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Image Tool supports these configuration parameters:
 | buttonContent | `string` | Allows to override HTML content of «Select file» button |
 | uploader | `{{uploadByFile: function, uploadByUrl: function}}` | Optional custom uploading methods. See details below. |
 | actions | `array` | Array with custom actions to show in the tool's settings menu. See details below. |
+| features | `object` | Allows you to enable/disable tunes along with caption. See details below. |
 
 Note that if you don't implement your custom uploader methods, the `endpoints` param is required.
 
@@ -113,6 +114,16 @@ actions: [
 ]
 ```
 
+Enable required tunes and caption by adding `features`-array in the configuration:
+```js
+features: {
+  background: true,
+  border: false,
+  caption: true,
+  stretched: true
+}
+```
+
 **_NOTE:_**  return value of `action` callback for settings whether action button should be toggled or not is *deprecated*. Consider using `toggle` option instead.
 
 ## Output data
@@ -122,10 +133,9 @@ This Tool returns `data` with following format
 | Field          | Type      | Description                     |
 | -------------- | --------- | ------------------------------- |
 | file           | `object`  | Uploaded file data. Any data got from backend uploader. Always contain the `url` property |
-| withCaption    | `boolean` | need to enable caption          |
 | caption        | `string`  | image's caption                 |
-| withBorder     | `boolean` | add border to image             |
-| withBackground | `boolean` | need to add background          |
+| border         | `boolean` | add border to image             |
+| background     | `boolean` | need to add background          |
 | stretched      | `boolean` | stretch image to screen's width |
 
 
@@ -137,10 +147,9 @@ This Tool returns `data` with following format
             "url" : "https://www.tesla.com/tesla_theme/assets/img/_vehicle_redesign/roadster_and_semi/roadster/hero.jpg"
         },
         "caption" : "Roadster // tesla.com",
-        "withBorder" : false,
-        "withBackground" : false,
+        "border" : false,
+        "background" : false,
         "stretched" : true,
-        "withCaption" : true,
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ You can disable features such as border, background tunes and caption by definin
 features: {
   border: false,
   caption: 'optional',
-  stretched: false
+  stretch: false
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Image Tool supports these configuration parameters:
 | buttonContent | `string` | Allows to override HTML content of «Select file» button |
 | uploader | `{{uploadByFile: function, uploadByUrl: function}}` | Optional custom uploading methods. See details below. |
 | actions | `array` | Array with custom actions to show in the tool's settings menu. See details below. |
-| features | `object` | Allows you to enable/disable tunes along with caption. See details below. |
+| features | `object` | Allows you to enable/disable additional features such as border, background tunes and caption. See details below. |
 
 Note that if you don't implement your custom uploader methods, the `endpoints` param is required.
 
@@ -114,17 +114,17 @@ actions: [
 ]
 ```
 
-Enable required tunes and caption by adding `features`-array in the configuration:
+**_NOTE:_**  return value of `action` callback for settings whether action button should be toggled or not is *deprecated*. Consider using `toggle` option instead.
+
+Enable features such as border, background tunes and caption by adding `features`-array in the configuration:
 ```js
 features: {
-  background: true,
-  border: false,
-  caption: true,
-  stretched: true
+  background: boolean,
+  border: boolean,
+  caption: boolean | 'optional',
+  stretched: boolean
 }
 ```
-
-**_NOTE:_**  return value of `action` callback for settings whether action button should be toggled or not is *deprecated*. Consider using `toggle` option instead.
 
 ## Output data
 
@@ -134,8 +134,8 @@ This Tool returns `data` with following format
 | -------------- | --------- | ------------------------------- |
 | file           | `object`  | Uploaded file data. Any data got from backend uploader. Always contain the `url` property |
 | caption        | `string`  | image's caption                 |
-| border         | `boolean` | add border to image             |
-| background     | `boolean` | need to add background          |
+| withBorder     | `boolean` | add border to image             |
+| withBackground | `boolean` | need to add background          |
 | stretched      | `boolean` | stretch image to screen's width |
 
 
@@ -147,8 +147,8 @@ This Tool returns `data` with following format
             "url" : "https://www.tesla.com/tesla_theme/assets/img/_vehicle_redesign/roadster_and_semi/roadster/hero.jpg"
         },
         "caption" : "Roadster // tesla.com",
-        "border" : false,
-        "background" : false,
+        "withBorder" : false,
+        "withBackground" : false,
         "stretched" : true,
     }
 }

--- a/README.md
+++ b/README.md
@@ -116,13 +116,12 @@ actions: [
 
 **_NOTE:_**  return value of `action` callback for settings whether action button should be toggled or not is *deprecated*. Consider using `toggle` option instead.
 
-You can enable/disable features such as border, background tunes and caption by adding `features` array in the configuration:
+You can disable features such as border, background tunes and caption by defining `features` in the configuration:
 ```js
 features: {
-  background: boolean,
-  border: boolean,
-  caption: boolean | 'optional',
-  stretched: boolean
+  border: false,
+  caption: 'optional',
+  stretched: false
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Image Block for the [Editor.js](https://editorjs.io).
 - Pasting copied content from the web
 - Pasting images by drag-n-drop
 - Pasting files and screenshots from Clipboard
-- Allows adding a border, and a background
+- Allows adding a border, a background and a caption
 - Allows stretching an image to the container's full-width
 
 **Notes**
@@ -96,6 +96,8 @@ Note that if you don't implement your custom uploader methods, the `endpoints` p
 
 3. Add background
 
+4. Add caption
+
 Add extra setting-buttons by adding them to the `actions`-array in the configuration:
 ```js
 actions: [
@@ -120,6 +122,7 @@ This Tool returns `data` with following format
 | Field          | Type      | Description                     |
 | -------------- | --------- | ------------------------------- |
 | file           | `object`  | Uploaded file data. Any data got from backend uploader. Always contain the `url` property |
+| withCaption    | `boolean` | need to enable caption          |
 | caption        | `string`  | image's caption                 |
 | withBorder     | `boolean` | add border to image             |
 | withBackground | `boolean` | need to add background          |
@@ -136,7 +139,8 @@ This Tool returns `data` with following format
         "caption" : "Roadster // tesla.com",
         "withBorder" : false,
         "withBackground" : false,
-        "stretched" : true
+        "stretched" : true,
+        "withCaption" : true,
     }
 }
 ```

--- a/dev/index.html
+++ b/dev/index.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Image Plugin Test | EditorJS</title>
+    <link
+      rel="stylesheet"
+      href="https://cdn.jsdelivr.net/npm/@editorjs/editorjs@latest/dist/editor.css"
+    />
+  </head>
+  <body>
+    <div id="editorjs"></div>
+    <script src="https://cdn.jsdelivr.net/npm/@editorjs/editorjs@latest/dist/editor.js"></script>
+    <script src="../dist/image.umd.js"></script>
+    <script>
+      const editor = new EditorJS({
+        holder: "editorjs",
+        tools: {
+          code: {
+            class: ImageTool,
+            config: {
+              endpoints: {
+                byFile: "http://localhost:8008/uploadFile",
+                byUrl: "http://localhost:8008/fetchUrl",
+              },
+              //features: ["withCaption", "withBorder", "stretched", "withBackground"],
+              features: ["withCaption", "withBorder"],
+            },
+          },
+        },
+      });
+    </script>
+  </body>
+</html>

--- a/dev/index.html
+++ b/dev/index.html
@@ -4,10 +4,6 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Image Plugin Test | EditorJS</title>
-    <link
-      rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/@editorjs/editorjs@latest/dist/editor.css"
-    />
   </head>
   <body>
     <div id="editorjs"></div>
@@ -24,8 +20,12 @@
                 byFile: "http://localhost:8008/uploadFile",
                 byUrl: "http://localhost:8008/fetchUrl",
               },
-              //features: ["withCaption", "withBorder", "stretched", "withBackground"],
-              features: ["withCaption", "withBorder"],
+              features: {
+                background: true,
+                border: true,
+                caption: true,
+                stretched: true,
+              },
             },
           },
         },

--- a/dev/index.html
+++ b/dev/index.html
@@ -21,9 +21,9 @@
                 byUrl: "http://localhost:8008/fetchUrl",
               },
               features: {
-                background: true,
-                border: true,
-                caption: true,
+                caption: "optional",
+                border: false,
+                background: false,
                 stretched: true,
               },
             },

--- a/dev/index.html
+++ b/dev/index.html
@@ -21,10 +21,10 @@
                 byUrl: "http://localhost:8008/fetchUrl",
               },
               features: {
-                caption: "optional",
+                // caption: false,
                 border: false,
                 background: false,
-                stretched: true,
+                stretch: false,
               },
             },
           },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@editorjs/image",
-  "version": "2.10",
+  "version": "2.10.0",
   "keywords": [
     "codex editor",
     "image",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@editorjs/image",
-  "version": "2.9.3",
+  "version": "2.10",
   "keywords": [
     "codex editor",
     "image",

--- a/src/index.css
+++ b/src/index.css
@@ -123,13 +123,13 @@
    * ----------------
    */
 
-  &--border {
+  &--withBorder {
     ^&__image {
       border: 1px solid var(--border-color);
     }
   }
 
-  &--background {
+  &--withBackground {
     ^&__image {
       padding: 15px;
       background: var(--bg-color);

--- a/src/index.css
+++ b/src/index.css
@@ -44,6 +44,8 @@
   }
 
   &__caption {
+    display: none;
+
     &[contentEditable="true"][data-placeholder]::before {
       position: absolute !important;
       content: attr(data-placeholder);
@@ -86,7 +88,7 @@
       margin: 0 6px 0 0;
     }
   }
-  
+
   &--filled {
     .cdx-button {
       display: none;
@@ -147,12 +149,18 @@
     }
   }
 
+  &--withCaption {
+    ^&__caption {
+      display: block;
+    }
+  }
 }
 
 @keyframes image-preloader-spin {
   0% {
     transform: rotate(0deg);
   }
+
   100% {
     transform: rotate(360deg);
   }

--- a/src/index.css
+++ b/src/index.css
@@ -123,13 +123,13 @@
    * ----------------
    */
 
-  &--withBorder {
+  &--border {
     ^&__image {
       border: 1px solid var(--border-color);
     }
   }
 
-  &--withBackground {
+  &--background {
     ^&__image {
       padding: 15px;
       background: var(--bg-color);
@@ -149,7 +149,7 @@
     }
   }
 
-  &--withCaption {
+  &--caption {
     ^&__caption {
       display: block;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,6 @@
  *  1) index.ts — main Tool's interface, public API and methods for working with data
  *  2) uploader.ts — module that has methods for sending files via AJAX: from device, by URL or File pasting
  *  3) ui.ts — module for UI manipulations: render, showing preloader, etc
- *  4) tunes.js — working with Block Tunes: render buttons, handle clicks
  *
  * For debug purposes there is a testing server
  * that can save uploaded files and return a Response {@link UploadResponseFormat}
@@ -37,7 +36,7 @@ import Ui from './ui';
 import Uploader from './uploader';
 
 import { IconAddBorder, IconStretch, IconAddBackground, IconPicture } from '@codexteam/icons';
-import type { ActionConfig, UploadResponseFormat, ImageToolData, ImageConfig, HTMLPasteEventDetailExtended, ImageSetterParam } from './types/types';
+import type { ActionConfig, UploadResponseFormat, ImageToolData, ImageConfig, HTMLPasteEventDetailExtended, ImageSetterParam, FeaturesConfig } from './types/types';
 
 type ImageToolConstructorOptions = BlockToolConstructorOptions<ImageToolData, ImageConfig>;
 
@@ -49,11 +48,6 @@ export default class ImageTool implements BlockTool {
    * Editor.js API instance
    */
   private api: API;
-
-  /**
-   * Flag indicating read-only mode
-   */
-  private readOnly: boolean;
 
   /**
    * Current Block API instance
@@ -90,7 +84,6 @@ export default class ImageTool implements BlockTool {
    */
   constructor({ data, config, api, readOnly, block }: ImageToolConstructorOptions) {
     this.api = api;
-    this.readOnly = readOnly;
     this.block = block;
 
     /**
@@ -106,6 +99,7 @@ export default class ImageTool implements BlockTool {
       buttonContent: config.buttonContent,
       uploader: config.uploader,
       actions: config.actions,
+      features: config.features,
     };
 
     /**
@@ -141,6 +135,7 @@ export default class ImageTool implements BlockTool {
       withBorder: false,
       withBackground: false,
       stretched: false,
+      withCaption: false,
       file: {
         url: '',
       },
@@ -190,6 +185,12 @@ export default class ImageTool implements BlockTool {
         title: 'With background',
         toggle: true,
       },
+      {
+        name: 'withCaption',
+        icon: IconAddBackground,
+        title: 'With caption',
+        toggle: true,
+      },
     ];
   }
 
@@ -228,8 +229,12 @@ export default class ImageTool implements BlockTool {
     // Merge default tunes with the ones that might be added by user
     // @see https://github.com/editor-js/image/pull/49
     const tunes = ImageTool.tunes.concat(this.config.actions || []);
+    const enabledTunes = this.config.features || [];
+    const availableTunes = tunes.filter(tune =>
+      enabledTunes.length === 0 || enabledTunes.includes(tune.name as FeaturesConfig)
+    );
 
-    return tunes.map(tune => ({
+    return availableTunes.map(tune => ({
       icon: tune.icon,
       label: this.api.i18n.t(tune.title),
       name: tune.name,

--- a/src/index.ts
+++ b/src/index.ts
@@ -135,7 +135,6 @@ export default class ImageTool implements BlockTool {
       withBorder: false,
       withBackground: false,
       stretched: false,
-      withCaption: false,
       file: {
         url: '',
       },
@@ -168,7 +167,7 @@ export default class ImageTool implements BlockTool {
   public static get tunes(): Array<ActionConfig> {
     return [
       {
-        name: 'withBorder',
+        name: 'border',
         icon: IconAddBorder,
         title: 'With border',
         toggle: true,
@@ -180,15 +179,9 @@ export default class ImageTool implements BlockTool {
         toggle: true,
       },
       {
-        name: 'withBackground',
+        name: 'background',
         icon: IconAddBackground,
         title: 'With background',
-        toggle: true,
-      },
-      {
-        name: 'withCaption',
-        icon: IconAddBackground,
-        title: 'With caption',
         toggle: true,
       },
     ];
@@ -198,6 +191,10 @@ export default class ImageTool implements BlockTool {
    * Renders Block content
    */
   public render(): HTMLDivElement {
+    if (this.config.features && this.config.features.caption) {
+      this.ui.toggleCaption(true);
+    }
+
     return this.ui.render(this.data) as HTMLDivElement;
   }
 
@@ -229,9 +226,11 @@ export default class ImageTool implements BlockTool {
     // Merge default tunes with the ones that might be added by user
     // @see https://github.com/editor-js/image/pull/49
     const tunes = ImageTool.tunes.concat(this.config.actions || []);
-    const enabledTunes = this.config.features || [];
-    const availableTunes = tunes.filter(tune =>
-      enabledTunes.length === 0 || enabledTunes.includes(tune.name as FeaturesConfig)
+    const availableTunes = tunes.filter((tune) => {
+      if (this.config.features) {
+        return this.config.features[tune.name as keyof FeaturesConfig];
+      }
+    }
     );
 
     return availableTunes.map(tune => ({

--- a/src/index.ts
+++ b/src/index.ts
@@ -229,7 +229,7 @@ export default class ImageTool implements BlockTool {
     const featureTuneMap: Record<string, string> = {
       border: 'withBorder',
       background: 'withBackground',
-      stretched: 'stretched',
+      stretch: 'stretched',
       caption: 'caption',
     };
 
@@ -421,6 +421,12 @@ export default class ImageTool implements BlockTool {
   private tuneToggled(tuneName: keyof ImageToolData): void {
     // inverse tune state
     this.setTune(tuneName, !(this._data[tuneName] as boolean));
+
+    // reset caption on toggle
+    if (tuneName === 'caption' && !this._data[tuneName]) {
+      this._data.caption = '';
+      this.ui.fillCaption('');
+    }
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -191,7 +191,7 @@ export default class ImageTool implements BlockTool {
    * Renders Block content
    */
   public render(): HTMLDivElement {
-    if (this.config.features && this.config.features.caption === true) {
+    if (this.config.features?.caption === true || (this.config.features?.caption === 'optional' && this.data.caption)) {
       this.ui.applyTune('caption', true);
     }
 
@@ -226,12 +226,12 @@ export default class ImageTool implements BlockTool {
     // Merge default tunes with the ones that might be added by user
     // @see https://github.com/editor-js/image/pull/49
     const tunes = ImageTool.tunes.concat(this.config.actions || []);
-    const featureTuneMap: Record<string, string> = {
-      border: 'withBorder',
-      background: 'withBackground',
-      stretched: 'stretched',
-      caption: 'caption',
-    };
+    const featureTuneMap = new Map<string, string>([
+      ['border', 'withBorder'],
+      ['background', 'withBackground'],
+      ['stretched', 'stretched'],
+      ['caption', 'caption'],
+    ]);
 
     if (this.config.features?.caption === 'optional') {
       tunes.push({
@@ -244,12 +244,19 @@ export default class ImageTool implements BlockTool {
 
     const availableTunes = tunes.filter((tune) => {
       if (this.config.features) {
-        const featureKey = Object.keys(featureTuneMap).find(key => featureTuneMap[key] === tune.name);
+        const featureKey = [...featureTuneMap.entries()].find(
+          ([, value]) => value === tune.name
+        )?.[0];
 
-        return this.config.features[featureKey as keyof FeaturesConfig];
+        if (featureKey != null) {
+          return this.config.features[featureKey as keyof FeaturesConfig];
+        }
+
+        return false;
       }
-    }
-    );
+
+      return false;
+    });
 
     return availableTunes.map(tune => ({
       icon: tune.icon,

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,7 @@ import './index.css';
 import Ui from './ui';
 import Uploader from './uploader';
 
-import { IconAddBorder, IconStretch, IconAddBackground, IconPicture } from '@codexteam/icons';
+import { IconAddBorder, IconStretch, IconAddBackground, IconPicture, IconText } from '@codexteam/icons';
 import type { ActionConfig, UploadResponseFormat, ImageToolData, ImageConfig, HTMLPasteEventDetailExtended, ImageSetterParam, FeaturesConfig } from './types/types';
 
 type ImageToolConstructorOptions = BlockToolConstructorOptions<ImageToolData, ImageConfig>;
@@ -167,7 +167,7 @@ export default class ImageTool implements BlockTool {
   public static get tunes(): Array<ActionConfig> {
     return [
       {
-        name: 'border',
+        name: 'withBorder',
         icon: IconAddBorder,
         title: 'With border',
         toggle: true,
@@ -179,7 +179,7 @@ export default class ImageTool implements BlockTool {
         toggle: true,
       },
       {
-        name: 'background',
+        name: 'withBackground',
         icon: IconAddBackground,
         title: 'With background',
         toggle: true,
@@ -191,8 +191,8 @@ export default class ImageTool implements BlockTool {
    * Renders Block content
    */
   public render(): HTMLDivElement {
-    if (this.config.features && this.config.features.caption) {
-      this.ui.toggleCaption(true);
+    if (this.config.features && this.config.features.caption === true) {
+      this.ui.applyTune('caption', true);
     }
 
     return this.ui.render(this.data) as HTMLDivElement;
@@ -226,9 +226,27 @@ export default class ImageTool implements BlockTool {
     // Merge default tunes with the ones that might be added by user
     // @see https://github.com/editor-js/image/pull/49
     const tunes = ImageTool.tunes.concat(this.config.actions || []);
+    const featureTuneMap: Record<string, string> = {
+      border: 'withBorder',
+      background: 'withBackground',
+      stretched: 'stretched',
+      caption: 'caption',
+    };
+
+    if (this.config.features?.caption === 'optional') {
+      tunes.push({
+        name: 'caption',
+        icon: IconText,
+        title: 'With caption',
+        toggle: true,
+      });
+    }
+
     const availableTunes = tunes.filter((tune) => {
       if (this.config.features) {
-        return this.config.features[tune.name as keyof FeaturesConfig];
+        const featureKey = Object.keys(featureTuneMap).find(key => featureTuneMap[key] === tune.name);
+
+        return this.config.features[featureKey as keyof FeaturesConfig];
       }
     }
     );

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -107,20 +107,20 @@ export type FeaturesConfig = {
   /**
    * Flag to enable/disable tune - background.
    */
-  background: boolean;
+  background?: boolean;
   /**
    * Flag to enable/disable tune - border.
    */
-  border: boolean;
+  border?: boolean;
   /**
    * Flag to enable/disable caption.
    * Can be set to 'optional' to allow users to toggle via block tunes.
    */
-  caption: boolean | 'optional';
+  caption?: boolean | 'optional';
   /**
    * Flag to enable/disable tune - stretched
    */
-  stretched: boolean;
+  stretched?: boolean;
 };
 
 /**

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -89,11 +89,6 @@ export type ImageToolData<Actions = {}, AdditionalFileData = {}> = {
   stretched: boolean;
 
   /**
-   * Flag indicating whether the image has caption
-   */
-  withCaption: boolean;
-
-  /**
    * Object containing the URL of the image file.
    * Also can contain any additional data.
    */
@@ -108,7 +103,16 @@ export type ImageToolData<Actions = {}, AdditionalFileData = {}> = {
 /**
  * @description Tunes that would be available on each image block.
  */
-export type FeaturesConfig = 'withCaption' | 'withBorder' | 'withBackground' | 'stretched';
+export type FeaturesConfig = {
+  /** Flag to enable/disable tune - background. */
+  background: boolean;
+  /** Flag to enable/disable tune - border */
+  border: boolean;
+  /** Flag to enable/disable caption */
+  caption: boolean;
+  /** Flag to enable/disable tune - stretched */
+  stretched: boolean;
+};
 
 /**
  *
@@ -185,7 +189,7 @@ export interface ImageConfig {
   /**
    * Tunes to be enabled.
    */
-  features?: FeaturesConfig[];
+  features?: FeaturesConfig;
 }
 
 /**

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -120,7 +120,7 @@ export type FeaturesConfig = {
   /**
    * Flag to enable/disable tune - stretched
    */
-  stretched?: boolean;
+  stretch?: boolean;
 };
 
 /**

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -101,7 +101,7 @@ export type ImageToolData<Actions = {}, AdditionalFileData = {}> = {
 } & (Actions extends Record<string, boolean> ? Actions : {});
 
 /**
- * @description Enable or disable features.
+ * @description Allows to enable or disable features.
  */
 export type FeaturesConfig = {
   /**
@@ -114,6 +114,7 @@ export type FeaturesConfig = {
   border: boolean;
   /**
    * Flag to enable/disable caption.
+   * Can be set to 'optional' to allow users to toggle via block tunes.
    */
   caption: boolean | 'optional';
   /**

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -89,6 +89,11 @@ export type ImageToolData<Actions = {}, AdditionalFileData = {}> = {
   stretched: boolean;
 
   /**
+   * Flag indicating whether the image has caption
+   */
+  withCaption: boolean;
+
+  /**
    * Object containing the URL of the image file.
    * Also can contain any additional data.
    */
@@ -99,6 +104,11 @@ export type ImageToolData<Actions = {}, AdditionalFileData = {}> = {
     url: string;
   } & AdditionalFileData;
 } & (Actions extends Record<string, boolean> ? Actions : {});
+
+/**
+ * @description Tunes that would be available on each image block.
+ */
+export type FeaturesConfig = 'withCaption' | 'withBorder' | 'withBackground' | 'stretched';
 
 /**
  *
@@ -171,6 +181,11 @@ export interface ImageConfig {
    * Additional actions for the tool.
    */
   actions?: ActionConfig[];
+
+  /**
+   * Tunes to be enabled.
+   */
+  features?: FeaturesConfig[];
 }
 
 /**

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -101,16 +101,24 @@ export type ImageToolData<Actions = {}, AdditionalFileData = {}> = {
 } & (Actions extends Record<string, boolean> ? Actions : {});
 
 /**
- * @description Tunes that would be available on each image block.
+ * @description Enable or disable features.
  */
 export type FeaturesConfig = {
-  /** Flag to enable/disable tune - background. */
+  /**
+   * Flag to enable/disable tune - background.
+   */
   background: boolean;
-  /** Flag to enable/disable tune - border */
+  /**
+   * Flag to enable/disable tune - border.
+   */
   border: boolean;
-  /** Flag to enable/disable caption */
-  caption: boolean;
-  /** Flag to enable/disable tune - stretched */
+  /**
+   * Flag to enable/disable caption.
+   */
+  caption: boolean | 'optional';
+  /**
+   * Flag to enable/disable tune - stretched
+   */
   stretched: boolean;
 };
 

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -255,6 +255,14 @@ export default class Ui {
   }
 
   /**
+   * Toggles caption input visibility
+   * @param status - true for enable, false for disable
+   */
+  public toggleCaption(status: boolean): void {
+    this.nodes.wrapper.classList.toggle(`${this.CSS.wrapper}--caption`, status);
+  }
+
+  /**
    * Shows caption input
    * @param text - caption content text
    */

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -255,14 +255,6 @@ export default class Ui {
   }
 
   /**
-   * Toggles caption input visibility
-   * @param status - true for enable, false for disable
-   */
-  public toggleCaption(status: boolean): void {
-    this.nodes.wrapper.classList.toggle(`${this.CSS.wrapper}--caption`, status);
-  }
-
-  /**
    * Shows caption input
    * @param text - caption content text
    */


### PR DESCRIPTION
## Problem:
Users were unable to configure which image tunes (e.g., caption, border, background) should be available in the ImageTool.

## Solution:
Implemented a mechanism that allows users to specify which tunes should be available via configuration. If no specific tunes are provided, all default tunes will be available.

#29 #236 