### PR TITLE
Fixed css styles for uploading state

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@editorjs/image",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "keywords": [
     "codex editor",
     "image",

--- a/src/index.css
+++ b/src/index.css
@@ -72,9 +72,9 @@
   }
 
   &--empty,
-  &--loading {
+  &--uploading {
     ^&__caption {
-      display: none;
+      display: none !important;
     }
   }
 
@@ -101,7 +101,7 @@
     }
   }
 
-  &--loading {
+  &--uploading {
     ^&__image {
       min-height: 200px;
       display: flex;


### PR DESCRIPTION
Now the image at upload time incorrectly shows nodes that should be hidden until the image is uploaded:
![image](https://github.com/user-attachments/assets/5e31b4bb-7f49-4196-b90a-ac5c201d6182)

This happened because during refactoring, the original “loading” class was renamed to “uploading” in the JS code, but missed in the CSS.

I fixed this problem.
