### PR TITLE
Add pre-render hook

### DIFF
--- a/dev/index.html
+++ b/dev/index.html
@@ -21,6 +21,7 @@
               data: {
                 file: {
                   url: "https://images.unsplash.com/photo-1607604276583-eef5d076aa5f?q=80&w=1974&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D",
+                  imageId: "this is a test"
                 },
                 withBorder: false,
                 withBackground: false,
@@ -35,6 +36,12 @@
           image: {
             class: ImageTool,
             config: {
+              renderPreHook: function (data) {
+                if (data.file.imageId !== undefined) {
+                  data.file.url = "https://plus.unsplash.com/premium_photo-1741194732785-4624b6e5f0b5?q=80&w=2433&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D"
+                }
+                return data;
+              },
               endpoints: {
                 byFile: "http://localhost:8008/uploadFile",
                 byUrl: "http://localhost:8008/fetchUrl",

--- a/package.json
+++ b/package.json
@@ -55,5 +55,6 @@
   },
   "dependencies": {
     "@codexteam/icons": "^0.3.0"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -98,6 +98,7 @@ export default class ImageTool implements BlockTool {
      * Tool's initial config
      */
     this.config = {
+      renderPreHook: config.renderPreHook,
       endpoints: config.endpoints,
       additionalRequestData: config.additionalRequestData,
       additionalRequestHeaders: config.additionalRequestHeaders,
@@ -281,7 +282,7 @@ export default class ImageTool implements BlockTool {
       toggle: tune.toggle,
       isActive: isActive(tune),
       onActivate: () => {
-        /** If it'a user defined tune, execute it's callback stored in action property */
+        /** If it's a user defined tune, execute its callback stored in action property */
         if (typeof tune.action === 'function') {
           tune.action(tune.name);
 
@@ -291,7 +292,7 @@ export default class ImageTool implements BlockTool {
 
         /**
          * For the caption tune, we can't rely on the this._data
-         * because it can be manualy toggled by user
+         * because it can be manually toggled by user
          */
         if (tune.name === 'caption') {
           this.isCaptionEnabled = !(this.isCaptionEnabled ?? false);
@@ -307,7 +308,7 @@ export default class ImageTool implements BlockTool {
    * Fires after clicks on the Toolbox Image Icon
    * Initiates click on the Select File button
    */
-  public appendCallback(): void {
+  public rendered(): void {
     this.ui.nodes.fileButton.click();
   }
 
@@ -420,6 +421,10 @@ export default class ImageTool implements BlockTool {
   private set image(file: ImageSetterParam | undefined) {
     this._data.file = file || { url: '' };
 
+    if (this.config.renderPreHook !== undefined) {
+      this._data = this.config.renderPreHook(this._data);
+    }
+
     if (file && file.url) {
       this.ui.fillImage(file.url);
     }
@@ -460,7 +465,7 @@ export default class ImageTool implements BlockTool {
     if (tuneName === 'caption') {
       this.ui.applyTune(tuneName, state);
 
-      if (state == false) {
+      if (!state) {
         this._data.caption = '';
         this.ui.fillCaption('');
       }

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -40,7 +40,7 @@ export interface ActionConfig {
    * An optional action function to be executed when the tune is activated.
    */
   action?: Function;
-};
+}
 
 /**
  * UploadResponseFormat interface representing the response format expected from the backend on file uploading.
@@ -65,7 +65,7 @@ export interface UploadResponseFormat<AdditionalFileData = {}> {
 }
 
 /**
- * ImageToolData type representing the input and output data format for the image tool, including optional custome actions.
+ * ImageToolData type representing the input and output data format for the image tool, including optional custom actions.
  */
 export type ImageToolData<Actions = {}, AdditionalFileData = {}> = {
   /**
@@ -89,8 +89,7 @@ export type ImageToolData<Actions = {}, AdditionalFileData = {}> = {
   stretched: boolean;
 
   /**
-   * Object containing the URL of the image file.
-   * Also can contain any additional data.
+   * Object containing the URL of the image file, can also contain additional data.
    */
   file: {
     /**
@@ -143,6 +142,13 @@ export interface ImageConfig {
      */
     byUrl?: string;
   };
+
+  /**
+   * Optional function that is run prior to rendering the image. This can prove useful for e.g. images that are
+   * uploaded to private s3 buckets and need a pre-signed url generate before they can be viewed.
+   * Input is a function that is allowed to mutate the imageToolData object.
+   */
+  renderPreHook?: (data: ImageToolData) => ImageToolData;
 
   /**
    * Field name for the uploaded image.


### PR DESCRIPTION
Adds optional configuration field where you can pass function that is run before the image is rendered.
An example of the use case of this is if images are uploaded to private s3 buckets (or other places where a signed url is needed to retreive the image).
The "identifier" of the image can be passed as additional data with the url and the pre-render hook can update the signed url.

this PR also closes #241.