### PR TITLE
fix: show caption when feature is enabled

### DIFF
--- a/dev/index.html
+++ b/dev/index.html
@@ -40,7 +40,7 @@
                 byUrl: "http://localhost:8008/fetchUrl",
               },
               features: {
-                caption: "optional",
+                caption: true,
                 border: false,
                 background: false,
                 stretch: true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@editorjs/image",
-  "version": "2.10.2",
+  "version": "2.10.3",
   "keywords": [
     "codex editor",
     "image",

--- a/src/index.ts
+++ b/src/index.ts
@@ -201,6 +201,7 @@ export default class ImageTool implements BlockTool {
   public render(): HTMLDivElement {
     if (this.config.features?.caption === true || this.config.features?.caption === undefined || (this.config.features?.caption === 'optional' && this.data.caption)) {
       this.isCaptionEnabled = true;
+      this.setTune('caption', true);
     }
 
     return this.ui.render() as HTMLDivElement;


### PR DESCRIPTION
The PR aims to fix the bug found at v2.10.2. If you explicitly enable the caption, it doesn't show up.

Example after changes:

![image](https://github.com/user-attachments/assets/8ed1c71d-5d03-4a8a-8cc2-112adfbd1083)
![image](https://github.com/user-attachments/assets/3f546c0b-ef3d-4a7e-9a5c-a629c266bcd0)
