### PR TITLE
Resize handle

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -8,6 +8,7 @@
     overflow: hidden;
     margin-bottom: 10px;
     padding-bottom: 0;
+    position: relative;
 
     &-picture {
       max-width: 100%;
@@ -41,6 +42,30 @@
         animation: image-preloader-spin 2s infinite linear;
         box-sizing: border-box;
       }
+    }
+
+    &-resize-handle {
+      position: absolute;
+      top: 50%;
+      right: 4px;
+      width: 14px;
+      height: 120px;
+      max-height: calc(100% - 8px);
+      background: rgba(0, 0, 0, 0.35);
+      border: 2px solid rgba(255, 255, 255, 0.95);
+      border-radius: 12px;
+      cursor: ew-resize;
+      transform: translateY(-50%);
+      opacity: 0;
+      transition: opacity 0.15s ease, background 0.15s ease;
+    }
+
+    &:hover &-resize-handle {
+      opacity: 1;
+    }
+
+    &-resize-handle:hover {
+      background: rgba(0, 0, 0, 0.5);
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -140,6 +140,7 @@ export default class ImageTool implements BlockTool {
      */
     this._data = {
       caption: '',
+      width: undefined,
       withBorder: false,
       withBackground: false,
       stretched: false,
@@ -223,6 +224,7 @@ export default class ImageTool implements BlockTool {
     const caption = this.ui.nodes.caption;
 
     this._data.caption = caption.innerHTML;
+    this._data.width = this.ui.getWidth();
 
     return this.data;
   }
@@ -394,7 +396,9 @@ export default class ImageTool implements BlockTool {
     this.image = data.file;
 
     this._data.caption = data.caption || '';
+    this._data.width = typeof data.width === 'number' ? data.width : undefined;
     this.ui.fillCaption(this._data.caption);
+    this.ui.applyWidth(this._data.width);
 
     ImageTool.tunes.forEach(({ name: tune }) => {
       const value = typeof data[tune as keyof ImageToolData] !== 'undefined' ? data[tune as keyof ImageToolData] === true || data[tune as keyof ImageToolData] === 'true' : false;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -72,6 +72,10 @@ export type ImageToolData<Actions = {}, AdditionalFileData = {}> = {
    * Caption for the image.
    */
   caption: string;
+  /**
+   * Optional width (in pixels) applied to the image container.
+   */
+  width?: number;
 
   /**
    * Flag indicating whether the image has a border.


### PR DESCRIPTION
Well, hello there! I'm on a bit of a sprint to make a nice wiki app, because nobody wants to use mediawiki 😅 

![ezgif com-video-to-webp-converter](https://github.com/user-attachments/assets/72121f1b-29c7-4292-95b3-30f6f57c40b1)

Anyways, here's the PR:

### Summary

Added draggable resize handle to the Image tool; width is stored in block data and reapplied on load.
Clamped resize to a minimum of 40px and to the parent container width to prevent overflow.
Preserves width in saved image data alongside file URL, caption, and tunes.
Handle shrinks to fit small images.

### Details

UI: right-edge handle appears on hover; dragging updates inline width and saved width field.
Data: width?: number added to the image block schema and serialization; existing data remains compatible.
Behaviour: width resets to auto when unset; read-only hides the handle.

### Testing

Insert image, upload/paste URL.
Drag handle to resize; save/reload and verify width persists.
Confirm min/max clamp (can’t exceed container), handle shrinks with small images, captions/tunes still work, and read-only has no handle.

### Notes

No dependency changes; lockfiles unchanged.