### PR TITLE
Add a custom file selector option

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,20 @@ var editor = EditorJS({
               }
             })
           }
+        },
+        /**
+         * Custom file picker
+         */
+        selectFiles(){
+          return MyFilePicker.select().then(() => {
+            return {
+              success: 1,
+              file: {
+                url: 'https://codex.so/upload/redactor_images/o_80beea670e49f04931ce9e3b2122ac70.jpg',
+                // any other image data you want to store, such as width, height, color, extension, etc
+              }
+            };
+          })
         }
       }
     }

--- a/README.md
+++ b/README.md
@@ -277,11 +277,11 @@ var editor = EditorJS({
            */
           uploadByUrl(url){
             // your ajax request for uploading
-            return MyAjax.upload(file).then(() => {
+            return MyAjax.upload(url).then(() => {
               return {
                 success: 1,
                 file: {
-                  url: 'https://codex.so/upload/redactor_images/o_e48549d1855c7fc1807308dd14990126.jpg',,
+                  url: 'https://codex.so/upload/redactor_images/o_e48549d1855c7fc1807308dd14990126.jpg',
                   // any other image data you want to store, such as width, height, color, extension, etc
                 }
               }

--- a/src/index.ts
+++ b/src/index.ts
@@ -106,6 +106,7 @@ export default class ImageTool implements BlockTool {
       captionPlaceholder: this.api.i18n.t(config.captionPlaceholder ?? 'Caption'),
       buttonContent: config.buttonContent,
       uploader: config.uploader,
+      selectFiles: config.selectFiles,
       actions: config.actions,
       features: config.features || {},
     };

--- a/src/index.ts
+++ b/src/index.ts
@@ -434,8 +434,10 @@ export default class ImageTool implements BlockTool {
    * @param response - uploading server response
    */
   private onUpload(response: UploadResponseFormat): void {
-    if (response.success && Boolean(response.file)) {
-      this.image = response.file;
+    if (response.success) {
+      if (Boolean(response.file)) {
+        this.image = response.file;
+      }
     } else {
       this.uploadingFailed('incorrect response: ' + JSON.stringify(response));
     }

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -191,6 +191,11 @@ export interface ImageConfig {
   };
 
   /**
+   * Method to select images using a custom file manager.
+   */
+  selectFiles?: () => Promise<UploadResponseFormat>;
+
+  /**
    * Additional actions for the tool.
    */
   actions?: ActionConfig[];

--- a/src/uploader.ts
+++ b/src/uploader.ts
@@ -71,8 +71,12 @@ export default class Uploader {
      */
     let upload: Promise<UploadResponseFormat>;
 
-    // custom uploading
-    if (this.config.uploader && typeof this.config.uploader.uploadByFile === 'function') {
+    // custom file select
+    if (this.config.selectFiles && typeof this.config.selectFiles === 'function') {
+      upload = this.config.selectFiles();
+
+      // custom uploading
+    } else if (this.config.uploader && typeof this.config.uploader.uploadByFile === 'function') {
       const uploadByFile = this.config.uploader.uploadByFile;
 
       upload = ajax.selectFiles({ accept: this.config.types ?? 'image/*' }).then((files: File[]) => {


### PR DESCRIPTION
This allows integration with CMS-type frameworks or alternative file upload tools. Based on #207 but updated to simplify the functionality and fix merge conflicts.